### PR TITLE
BeagleBone WIP tracker

### DIFF
--- a/TODO[Seth]
+++ b/TODO[Seth]
@@ -14,4 +14,6 @@ refactor omap3_mmc from a "qdev" to whatever happened to the omap2 mmc and uarts
 
 what counts as an MMC sd card, and when might that be turned on? So far it's always false
 
+overall:
 
+https://lists.gnu.org/archive/html/qemu-devel/2015-05/msg00137.html


### PR DESCRIPTION
I'm not sure how to turn on issues for this fork, but PRs work.

Per https://lists.gnu.org/archive/html/qemu-devel/2015-05/msg00137.html the work to getting emulation for BeagleBone Black would be:

> 1) rebase the patchset on to qemu master and fix up
>   the breakage due to API changes in qemu
> [this will be moderately painful if you haven't been
> following the API changes as they happened; if you're
> interested in taking on the omap3 patches then I can
> do this step for you because it will be a lot faster...]
> 2) add support for direct boot of a guest kernel via
>   "-kernel" (currently only "boot via an SD card image"
>   is supported, which is awkward because the u-boot
>   image insists on checking every device on the board
>   and won't boot if any are missing)
> 3) build a cut-down minimally configured kernel that
>   only needs the smallest possible set of devices
>   [in particular, no SPI, I2C, MMC or graphics]
> 4) reorder the patchstack so that it starts with
>   those relating to the required minimal device set
>   and the SoC model and the board model, and the
>   complicated ones to do with I2C etc are afterwards;
>   check the kernel boots on this initial set
> 5) update the patches to correspond to current QEMU
>   practice for QOM device modelling (the code in that
>   tree is somewhat old and does many things in out
>   of date ways)
> 6) submit the minimal-device patches and get them
>   through code review and into QEMU
> 7) then start trying to clean up the remaining
>   patches one device at a time

So far the beagle-experimental branch is doing #1 to the best of my ability.